### PR TITLE
解决windows无法pip install的问题

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 install_requires = ['portalocker>=1.5.2']
 
 setuptools.setup(
     name="concurrent_log",
-    version="1.0.0",
+    version="1.0.1",
     author="HuangYiwei",
     author_email="huanghyw@gmail.com",
     description="多进程并发日志处理器",


### PR DESCRIPTION
Fixes #1 

setup.py中读取utf8编码的readme.md时未指定文件编码，如果使用windows系统会采用默认编码gbk进行读取，所以出现错误